### PR TITLE
Update model.cfg

### DIFF
--- a/Test_Building/model.cfg
+++ b/Test_Building/model.cfg
@@ -28,6 +28,11 @@ class CfgModels
 	class sample_building: Default
 	{
 		skeletonName = "Skeleton_3doors";
+		sections[] = {
+			"door1",
+			"door2",
+			"door3"
+		};
 		class Animations
 		{
 			class Door1


### PR DESCRIPTION
Fix Model config animations not working ingame because of missing selections. The old version will work in Buldozer, but inspecting the binazired p3d with Eliteness shows an empy model.cfg